### PR TITLE
#41 Implemented framework for supporting multiple custom item fragments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: android
 jdk: oraclejdk7
 before_install:
  - chmod +x gradlew
+ - echo yes | android update sdk --all --filter build-tools-21.1.2 --no-ui --force > /dev/null
 
 env:
   matrix:

--- a/app/src/main/java/com/codefororlando/transport/controller/BikeMapController.java
+++ b/app/src/main/java/com/codefororlando/transport/controller/BikeMapController.java
@@ -102,7 +102,7 @@ public class BikeMapController implements FeatureCollectionLoader.FeatureCollect
     public boolean onMarkerClick(Marker marker) {
         BikeRackItem bikeRackItem = bikeRackManager.getBikeRackItem(marker);
 
-        Intent intent = new Intent(MapsActivity.ACTION_MARKER_SELECTED);
+        Intent intent = new Intent(MapsActivity.ACTION_BIKE_MARKER_SELECTED);
         intent.putExtra(MapsActivity.EXTRA_BIKE_RACK_ITEM, bikeRackItem);
         LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
 

--- a/app/src/main/java/com/codefororlando/transport/fragment/FragmentRack.java
+++ b/app/src/main/java/com/codefororlando/transport/fragment/FragmentRack.java
@@ -1,7 +1,6 @@
 package com.codefororlando.transport.fragment;
 
 import android.app.Fragment;
-import android.app.FragmentManager;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -10,17 +9,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateDecelerateInterpolator;
-import android.view.animation.Animation;
-import android.view.animation.TranslateAnimation;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.codefororlando.transport.MapsActivity;
-import com.codefororlando.transport.animation.EmptyAnimationListener;
 import com.codefororlando.transport.bikeorlando.R;
 import com.codefororlando.transport.data.BikeRackItem;
 
-public class FragmentRack extends Fragment implements View.OnClickListener {
+public class FragmentRack extends Fragment implements View.OnClickListener, ISelectableItemFragment {
 
     public static final String TAG = FragmentRack.class.getName();
 
@@ -39,30 +35,6 @@ public class FragmentRack extends Fragment implements View.OnClickListener {
         fragment.setArguments(bundle);
 
         return fragment;
-    }
-
-    public void removeFragment() {
-        final View view = getView();
-        if (view == null) {
-            return;
-        }
-
-        final FragmentManager fragmentManager = getFragmentManager();
-        final Animation animation = new TranslateAnimation(0, 0, 0, view.getHeight());
-        animation.setDuration(getResources().getInteger(android.R.integer.config_shortAnimTime));
-        animation.setAnimationListener(new EmptyAnimationListener() {
-            @Override
-            public void onAnimationEnd(Animation animation) {
-                try {
-                    fragmentManager.beginTransaction()
-                            .remove(FragmentRack.this)
-                            .commitAllowingStateLoss();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-        });
-        view.startAnimation(animation);
     }
 
     @Override

--- a/app/src/main/java/com/codefororlando/transport/fragment/ISelectableItemFragment.java
+++ b/app/src/main/java/com/codefororlando/transport/fragment/ISelectableItemFragment.java
@@ -1,0 +1,7 @@
+package com.codefororlando.transport.fragment;
+
+public interface ISelectableItemFragment {
+
+    public static final String TAG = "ISelectableItemFragment";
+
+}


### PR DESCRIPTION
- New approach will require only minimal changes to MainActivity to support new fragment types.
- Fragments should be shown with showSelectableItemFragment(fragment) and removal should not be used directly.
- New fragments shall also implement ISelectableItemFragment as a requirement of the implementation.